### PR TITLE
Fix race condition in display signal handlers

### DIFF
--- a/scripts/display_manager.sh
+++ b/scripts/display_manager.sh
@@ -27,6 +27,12 @@ switch_to_builtin_mode() {
 
     sleep 1  # Let macOS settle after display change
 
+    # Verify we still have only 1 display (guard against race condition)
+    if [[ $(get_display_count) -gt 1 ]]; then
+        log "Aborting built-in mode: external display now connected"
+        return 0
+    fi
+
     # Set all spaces to float layout
     local spaces=$(yabai -m query --spaces | jq -r '.[].index')
     for space in $spaces; do
@@ -56,6 +62,12 @@ switch_to_external_mode() {
     log "Switching to external mode (BSP)..."
 
     sleep 2  # Let macOS settle after display change
+
+    # Verify we still have multiple displays (guard against race condition)
+    if [[ $(get_display_count) -eq 1 ]]; then
+        log "Aborting external mode: only built-in display present"
+        return 0
+    fi
 
     # Set all spaces to BSP layout
     local spaces=$(yabai -m query --spaces | jq -r '.[].index')

--- a/scripts/on_display_added.sh
+++ b/scripts/on_display_added.sh
@@ -1,8 +1,33 @@
 #!/usr/bin/env bash
 #
 # Handler for display_added event
-# Called by yabai when an external display is connected
+# Called by yabai when a display is connected
+#
+# Environment variables from yabai:
+#   $YABAI_DISPLAY_ID - UUID of the added display
+#   $YABAI_DISPLAY_INDEX - Index of the added display
 #
 
 SCRIPT_DIR="$(dirname "$0")"
+STATE_DIR="$HOME/.config/yabai/state"
+LOG_FILE="$STATE_DIR/display_manager.log"
+
+# UUID of the built-in MacBook display (ignore this one)
+BUILTIN_DISPLAY_UUID="37D8832A-2D66-02CA-B9F7-8F30A301B230"
+
+mkdir -p "$STATE_DIR"
+
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" >> "$LOG_FILE"
+}
+
+log "display_added signal received: ID=$YABAI_DISPLAY_ID INDEX=$YABAI_DISPLAY_INDEX"
+
+# Ignore if the built-in display was added (e.g., lid opened)
+if [[ "$YABAI_DISPLAY_ID" == "$BUILTIN_DISPLAY_UUID" ]]; then
+    log "Ignoring display_added for built-in display"
+    exit 0
+fi
+
+log "External display added, switching to BSP mode"
 "$SCRIPT_DIR/display_manager.sh" added

--- a/scripts/on_display_removed.sh
+++ b/scripts/on_display_removed.sh
@@ -1,8 +1,33 @@
 #!/usr/bin/env bash
 #
 # Handler for display_removed event
-# Called by yabai when an external display is disconnected
+# Called by yabai when a display is disconnected
+#
+# Environment variables from yabai:
+#   $YABAI_DISPLAY_ID - UUID of the removed display
 #
 
 SCRIPT_DIR="$(dirname "$0")"
+STATE_DIR="$HOME/.config/yabai/state"
+LOG_FILE="$STATE_DIR/display_manager.log"
+
+# UUID of the built-in MacBook display
+BUILTIN_DISPLAY_UUID="37D8832A-2D66-02CA-B9F7-8F30A301B230"
+
+mkdir -p "$STATE_DIR"
+
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" >> "$LOG_FILE"
+}
+
+log "display_removed signal received: ID=$YABAI_DISPLAY_ID"
+
+# If built-in display was removed (lid closed), no action needed
+# (external display becomes primary, keep BSP mode)
+if [[ "$YABAI_DISPLAY_ID" == "$BUILTIN_DISPLAY_UUID" ]]; then
+    log "Built-in display removed (lid closed), keeping current mode"
+    exit 0
+fi
+
+log "External display removed, switching to built-in mode"
 "$SCRIPT_DIR/display_manager.sh" removed


### PR DESCRIPTION
## Summary

- Use `$YABAI_DISPLAY_ID` environment variable to distinguish between built-in and external displays
- Ignore `display_added`/`display_removed` events for the built-in display UUID
- Add safety guards in `display_manager.sh` to verify display count after sleep delay

Closes #1

## Test plan

- [ ] Disconnect external display while opening MacBook lid
- [ ] Verify logs show "Ignoring display_added for built-in display"
- [ ] Verify windows switch to float + maximize mode (not BSP)
- [ ] Connect external display and verify BSP mode activates

🤖 Generated with [Claude Code](https://claude.com/claude-code)